### PR TITLE
Correct interpreter, fix gofmt execution.

### DIFF
--- a/fmt-check
+++ b/fmt-check
@@ -4,12 +4,12 @@ test_fmt() {
     hash gofmt 2>&- || { echo >&2 "gofmt not in PATH."; exit 1; }
     IFS='
 '
-    for file in $(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+    for file in `git diff --cached --name-only --diff-filter=ACM | grep '\.go$'`
     do
-        output=$(git cat-file -p :$file | gofmt -l 2>&1)
+        output=`git cat-file -p :$file | gofmt -l 2>&1`
         if test $? -ne 0
         then
-            output=$(echo "$output" | sed "s,<standard input>,$file,")
+            output=`echo "$output" | sed "s,<standard input>,$file,"`
             syntaxerrors="${list}${output}\n"
         elif test -n "$output"
         then

--- a/fmt-fix
+++ b/fmt-fix
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # NOTE: This script does not play well when adding partial changes, such as with
 # git add -p or git commit -p.
 
@@ -9,7 +9,7 @@ test_fmt() {
     exitcode=0
     for file in $(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
     do
-        output=gofmt -w "$file"
+        output=$(gofmt -w "$file")
         if test -n "$output"
         then
             # any output is a syntax error

--- a/fmt-fix
+++ b/fmt-fix
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # NOTE: This script does not play well when adding partial changes, such as with
 # git add -p or git commit -p.
 
@@ -7,9 +7,9 @@ test_fmt() {
     IFS='
 '
     exitcode=0
-    for file in $(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+    for file in `git diff --cached --name-only --diff-filter=ACM | grep '\.go$'`
     do
-        output=$(gofmt -w "$file")
+        output=`gofmt -w "$file"`
         if test -n "$output"
         then
             # any output is a syntax error


### PR DESCRIPTION
Fixes:
- Script used bash syntax, e.g: $(...), not plain bourne shell (sh).
    Changing the interpreter in line with this.
- The line output=gofmt -w "$file" interpretted "output=gofmt" as
    setting an environment variable, and -w as a command. This change
    corrects to what was intended.
