### PR TITLE
Remind users to run git add

### DIFF
--- a/fmt-check
+++ b/fmt-check
@@ -25,7 +25,7 @@ test_fmt() {
     fi
     if test -n "$list"
     then
-        echo >&2 "gofmt needs to format these files (run gofmt -w):"
+        echo >&2 "gofmt needs to format these files (run gofmt -w and git add):"
         printf "$list"
         exitcode=1
     fi


### PR DESCRIPTION
It is confusing to run gofmt -w as instructed only to get the exact same
error when retrying the commit because you forgot to add the changes
gofmt made to the commit. This change avoids that confusion.

Running exactly "git add" will give an error message reminding you to
tell it what to add. Since we don't know what that is (it could be a
patch fragment), we can't include it in our message so this is fine.
