### PR TITLE
Remove second set of single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sure it's executable.
 
 You might also find it useful to create a git alias for gofmt by running:
 
-    git config --global alias.gofmt '!echo $(git diff --cached --name-only --diff-filter=ACM | grep '.go$') | xargs gofmt -w -l | xargs git add'
+    git config --global alias.gofmt '!echo $(git diff --cached --name-only --diff-filter=ACM | grep \.go$) | xargs gofmt -w -l | xargs git add'
 
 Then you can run git gofmt and format all modified .go files. Note that this alias
 will not handle situations where partial file changes have been added to the index.


### PR DESCRIPTION
The quotes around the regex was not quoting the regex but instead terminating the first quote and starting a new quoted string. This lead to the dollar sign being dropped. The regex actually doesn't need any quoting so they can just be removed.

Also, the dot needs to be escaped.